### PR TITLE
Fix for IE8 "Not Implemented" issue

### DIFF
--- a/jquery.reel.js
+++ b/jquery.reel.js
@@ -1013,7 +1013,7 @@
                   setup: function(e){
                     var
                       width= get(_width_),
-                      height= get(_height_)
+                      height= get(_height_),
                       frames= get(_frames_),
                       id= t.attr(_id_),
                       rows= opt.rows,


### PR DESCRIPTION
A missing comma breaks the script in IE8.
