### PR TITLE
Background Height calculation

### DIFF
--- a/jquery.reel.js
+++ b/jquery.reel.js
@@ -1973,7 +1973,7 @@
                       size= get(_images_).length
                         ? !stitched ? undefined : px(stitched)+___+px(height)
                         : stitched && px(stitched)+___+px((height + spacing) * rows - spacing)
-                        || px((get(_width_) + spacing) * get(_footage_) - spacing)+___+px((height + spacing) * get(_rows_) * rows * (opt.directional? 2:1) - spacing)
+                        || px((get(_width_) + spacing) * get(_footage_) - spacing)+___+px((height + spacing) * ceil((get(_frames_) * rows) / opt.footage) * (opt.directional? 2:1) - spacing)
                     t.css({
                       height: is_sprite ? px(height) : null,
                       backgroundSize: size || null

--- a/jquery.reel.js
+++ b/jquery.reel.js
@@ -1269,7 +1269,7 @@
                     set(_loading_, true);
                     t.trigger('stop');
                     opt.responsive && gauge();
-                    t.trigger(_resize_, true);
+                    t.trigger('resize', true);
                     while(preload.length){
                       var
                         uri= reel.substitute(opt.path+preload.shift(), get),
@@ -1979,6 +1979,7 @@
                       backgroundSize: size || null
                     });
                     force || t.trigger('imagesChange');
+                    return false;
                   },
 
                   // ----------------
@@ -2192,7 +2193,8 @@
                   truescale= get(_truescale_),
                   ratio= set(_ratio_, t.width() / truescale.width)
                 $.each(truescale, function(key, value){ set(key, round(value * ratio)) })
-                t.trigger('resize');
+                //t.trigger('resize');
+                t.trigger(_resize_);
               },
 
               // - Delay timer pointers

--- a/jquery.reel.js
+++ b/jquery.reel.js
@@ -1269,7 +1269,7 @@
                     set(_loading_, true);
                     t.trigger('stop');
                     opt.responsive && gauge();
-                    t.trigger('resize', true);
+                    t.trigger(_resize_, true);
                     while(preload.length){
                       var
                         uri= reel.substitute(opt.path+preload.shift(), get),

--- a/jquery.reel.js
+++ b/jquery.reel.js
@@ -2344,7 +2344,7 @@
       // ### `$.reel.cdn` ######
       // `String` (URL path), since 1.1
       //
-      cdn: 'http://code.vostrel.net/',
+      cdn: (document.location.protocol === 'https:' ? 'https:' : ' http:')+'{{cdn:url}}/{{branch}}/assets/',
 
       // -----------
       // Math Behind


### PR DESCRIPTION
I was finding that if my sprite had any blank tiles (normally 2 at the end) in my multi row reels, then the background was being shrunk by one `height`. This small change calculates the height correctly in these cases.
